### PR TITLE
docs: Updates readme with a few editor configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,49 @@ Emacs or Vim
 - completion
 - formatting
 
+### Editor Configuration
+
+#### Neovim
+
+Either install the `ginko_ls` manually, or you can install with [`:Mason`](https://github.com/williamboman/mason.nvim).
+
+Configure the server with [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig) with the
+configuration name [`ginko_ls`](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#als).
+
+In order to configure it, simply add the following to your `init.lua`
+
+```lua
+lspconfig = require('lspconfig')
+lspconfig['ginko_ls'].setup({
+  on_attach = on_attach,
+  capabilities = capabilities
+})
+```
+
+This assumes you have `on_attach` and `capabilities` defined, see the `nvim-lspconfig` docs for more information.
+
+#### VSCode
+
+Use [Ginko VSCode](https://github.com/Schottkyc137/ginko_vscode)
+
+#### Helix
+
+If you want to use the [Helix Editor](https://docs.helix-editor.com/languages.html), you can custom define a
+custom language in `languages.toml`. An example is below.
+
+```toml
+[[language]]
+name = "dts"
+scope = "source.dts"
+file-types = ["dts", "dtsi"]
+comment-token = "//"
+indent = { tab-width = 4, unit = "    " }
+roots = [".git"]
+language-servers = ["ginko_ls"]
+
+[language-server.ginko_ls]
+command = "ginko_ls"
+config = { provideFormatter = false }
+```
+
 All contributions, whether in the form of Pull Requests or Issues are highly appreciated and welcome.

--- a/README.md
+++ b/README.md
@@ -116,17 +116,13 @@ Use [Ginko VSCode](https://github.com/Schottkyc137/ginko_vscode)
 
 #### Helix
 
-If you want to use the [Helix Editor](https://docs.helix-editor.com/languages.html), you can custom define a
-custom language in `languages.toml`. An example is below.
+If you want to use the [Helix
+Editor](https://docs.helix-editor.com/languages.html), you can modify the
+`devicetree` language definition in `languages.toml`. An example is below.
 
 ```toml
 [[language]]
-name = "dts"
-scope = "source.dts"
-file-types = ["dts", "dtsi"]
-comment-token = "//"
-indent = { tab-width = 4, unit = "    " }
-roots = [".git"]
+name = "devicetree"
 language-servers = ["ginko_ls"]
 
 [language-server.ginko_ls]


### PR DESCRIPTION
Adds installation/configuration instructions for a few different editors, including Neovim, VSCode, and Helix.

This PR shouldn't be merged until these two are finalized for the instructions I wrote for neovim:
- https://github.com/neovim/nvim-lspconfig/pull/3086
- https://github.com/mason-org/mason-registry/pull/5056

I am excited about this project, and figure more people can use it easily if they are sure how to use it in their editors.