### PR TITLE
Question: What the reason of not consider any files to device-tree source other than 'dts?' ?

### DIFF
--- a/ginko_ls/src/server.rs
+++ b/ginko_ls/src/server.rs
@@ -97,7 +97,8 @@ impl LanguageServer for Backend {
         let file_type = FileType::from(file_path.as_path());
         if file_type == FileType::Unknown {
             self.client.show_message(MessageType::WARNING, format!("File {} cannot be associated to a device-tree source. Make sure it has the ending 'dts', 'dtsi' or 'dtso'", file_path.to_string_lossy())).await;
-            return;
+            // Even other than those files will be considered to device-tree source but the warning.
+            // return;
         }
         self.project
             .write()


### PR DESCRIPTION
Thank you for your great work around DTS!  

I write DTS files most every single day for [Zephyr](https://www.zephyrproject.org/) the embedded OS not for Linux.

When using Zephyr, the file name of the DTS are not `*.dts?` in many case. For example `foo.overlay` is actually DTS such like this:

```dts:foo.overlay
// blinky/boards/xiao_esp32c3.overlay

/ {

    aliases {
        led0 = &led_D0;
    };

    leds {
        compatible = "gpio-leds";
        led_D0: led_0 {
            gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
            label = "LED D0";
        };
    };
};
```

I am using `ginko_ls` that is patched like this PR as an LSP server with Emacs and without any troubles.

Would you tell me the reasons the `ginko_ls` limits to associate only `*.dts?` to device-tree sources.

Thank you.