### PR TITLE
Feat: add include path option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,8 @@ dependencies = [
  "ginko",
  "itertools",
  "parking_lot",
+ "serde",
+ "serde_json",
  "tokio",
  "tower-lsp",
  "tracing-subscriber",

--- a/ginko/src/dts/analysis.rs
+++ b/ginko/src/dts/analysis.rs
@@ -380,7 +380,7 @@ mod test {
     use crate::dts::data::{HasSource, HasSpan, Position};
     use crate::dts::error_codes::ErrorCode;
     use crate::dts::test::Code;
-    use crate::dts::{Diagnostic, ParserContext};
+    use crate::dts::Diagnostic;
     use assert_unordered::assert_eq_unordered;
 
     #[test]

--- a/ginko/src/dts/analysis.rs
+++ b/ginko/src/dts/analysis.rs
@@ -396,9 +396,7 @@ mod test {
         another_ill#gal_label: sub_node {};
     };
     illegal_node_name#s {};
-};", ParserContext {
-  include_paths: Vec::new(),
-},
+};", ParserContext::default(),
         );
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq_unordered!(
@@ -452,9 +450,7 @@ mod test {
             self-reference = &node4;
         };
     };
-};", ParserContext {
-  include_paths: Vec::new(),
-},
+};", ParserContext::default(),
         );
         let (diagnostics, context) = code.get_analyzed_file();
         assert_eq_unordered!(
@@ -517,9 +513,7 @@ mod test {
             self-reference = &node4;
         };
     };
-};", ParserContext {
-  include_paths: Vec::new(),
-},
+};", ParserContext::default(),
         );
         let (diag, context) = code.get_analyzed_file();
         assert!(diag.is_empty());
@@ -555,9 +549,7 @@ mod test {
 
     #[test]
     pub fn test_does_not_accept_non_dtsv1_sources() {
-        let code = Code::new("/ {};", ParserContext {
-          include_paths: Vec::new(),
-      },);
+        let code = Code::new("/ {};", ParserContext::default());
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq!(
             diagnostics,
@@ -588,9 +580,7 @@ mod test {
 
 &{/some_other_node} {};
 
-", ParserContext {
-  include_paths: Vec::new(),
-},
+", ParserContext::default()
         );
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq_unordered!(

--- a/ginko/src/dts/analysis.rs
+++ b/ginko/src/dts/analysis.rs
@@ -396,7 +396,7 @@ mod test {
         another_ill#gal_label: sub_node {};
     };
     illegal_node_name#s {};
-};", ParserContext::default(),
+};",
         );
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq_unordered!(
@@ -450,7 +450,7 @@ mod test {
             self-reference = &node4;
         };
     };
-};", ParserContext::default(),
+};",
         );
         let (diagnostics, context) = code.get_analyzed_file();
         assert_eq_unordered!(
@@ -513,7 +513,7 @@ mod test {
             self-reference = &node4;
         };
     };
-};", ParserContext::default(),
+};",
         );
         let (diag, context) = code.get_analyzed_file();
         assert!(diag.is_empty());
@@ -549,7 +549,7 @@ mod test {
 
     #[test]
     pub fn test_does_not_accept_non_dtsv1_sources() {
-        let code = Code::new("/ {};", ParserContext::default());
+        let code = Code::new("/ {};");
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq!(
             diagnostics,
@@ -580,7 +580,7 @@ mod test {
 
 &{/some_other_node} {};
 
-", ParserContext::default()
+",
         );
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq_unordered!(

--- a/ginko/src/dts/analysis.rs
+++ b/ginko/src/dts/analysis.rs
@@ -380,7 +380,7 @@ mod test {
     use crate::dts::data::{HasSource, HasSpan, Position};
     use crate::dts::error_codes::ErrorCode;
     use crate::dts::test::Code;
-    use crate::dts::Diagnostic;
+    use crate::dts::{Diagnostic, ParserContext};
     use assert_unordered::assert_eq_unordered;
 
     #[test]
@@ -389,14 +389,16 @@ mod test {
             "\
 /dts-v1/;
 
-/{ 
-    my_l?abel: some_node {}; 
+/{
+    my_l?abel: some_node {};
     my_label_that_has_more_than_31_characters: other_node {};
     some_other_node {
         another_ill#gal_label: sub_node {};
     };
     illegal_node_name#s {};
-};",
+};", ParserContext {
+  include_paths: Vec::new(),
+},
         );
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq_unordered!(
@@ -436,7 +438,7 @@ mod test {
             "\
 /dts-v1/;
 
-/{ 
+/{
     node1: some_node {
         ref-to-node2 = &node2;
         ref-to-node3 = <&node3>;
@@ -450,7 +452,9 @@ mod test {
             self-reference = &node4;
         };
     };
-};",
+};", ParserContext {
+  include_paths: Vec::new(),
+},
         );
         let (diagnostics, context) = code.get_analyzed_file();
         assert_eq_unordered!(
@@ -503,7 +507,7 @@ mod test {
             "\
 /dts-v1/;
 
-/{ 
+/{
     node1: some_node {
         ref-to-node2 = &node2;
     };
@@ -513,7 +517,9 @@ mod test {
             self-reference = &node4;
         };
     };
-};",
+};", ParserContext {
+  include_paths: Vec::new(),
+},
         );
         let (diag, context) = code.get_analyzed_file();
         assert!(diag.is_empty());
@@ -549,7 +555,9 @@ mod test {
 
     #[test]
     pub fn test_does_not_accept_non_dtsv1_sources() {
-        let code = Code::new("/ {};");
+        let code = Code::new("/ {};", ParserContext {
+          include_paths: Vec::new(),
+      },);
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq!(
             diagnostics,
@@ -580,7 +588,9 @@ mod test {
 
 &{/some_other_node} {};
 
-",
+", ParserContext {
+  include_paths: Vec::new(),
+},
         );
         let (diagnostics, _) = code.get_analyzed_file();
         assert_eq_unordered!(

--- a/ginko/src/dts/ast.rs
+++ b/ginko/src/dts/ast.rs
@@ -472,19 +472,16 @@ impl Display for Include {
 
 impl Include {
     pub fn path(&self) -> Result<PathBuf, io::Error> {
-        for include_path in self.include_paths.iter() {
-            let mut path = PathBuf::new();
-            path.push(include_path);
-            path.push(self.file_name.to_string());
+        let include_resolved = self.include_paths.iter().find_map(|include_path| {
+            let path = include_path.join(self.file_name.to_string());
+            dunce::canonicalize(path).ok()
+        });
 
-            let result = dunce::canonicalize(path);
-
-            if result.is_ok() {
-              return result;
-            }
+        if let Some(include_resolved) = include_resolved {
+            Ok(include_resolved)
+        } else {
+            dunce::canonicalize(self.file_name.to_string())
         }
-
-        dunce::canonicalize(self.file_name.to_string())
     }
 }
 

--- a/ginko/src/dts/ast.rs
+++ b/ginko/src/dts/ast.rs
@@ -449,6 +449,7 @@ impl Display for DtsFile {
 pub struct Include {
     pub include_token: Token,
     pub file_name: WithToken<String>,
+    pub include_paths: Vec<PathBuf>,
 }
 
 impl HasSpan for Include {
@@ -471,7 +472,19 @@ impl Display for Include {
 
 impl Include {
     pub fn path(&self) -> Result<PathBuf, io::Error> {
-        dunce::canonicalize(self.file_name.item())
+        for include_path in self.include_paths.clone().iter_mut() {
+            let mut path = PathBuf::new();
+            path.push(include_path);
+            path.push(self.file_name.to_string());
+
+            let result = dunce::canonicalize(path);
+
+            if result.is_ok() {
+              return result;
+            }
+        }
+
+        dunce::canonicalize(self.file_name.to_string())
     }
 }
 

--- a/ginko/src/dts/ast.rs
+++ b/ginko/src/dts/ast.rs
@@ -472,7 +472,7 @@ impl Display for Include {
 
 impl Include {
     pub fn path(&self) -> Result<PathBuf, io::Error> {
-        for include_path in self.include_paths.clone().iter_mut() {
+        for include_path in self.include_paths.iter() {
             let mut path = PathBuf::new();
             path.push(include_path);
             path.push(self.file_name.to_string());

--- a/ginko/src/dts/diagnostics.rs
+++ b/ginko/src/dts/diagnostics.rs
@@ -239,9 +239,7 @@ mod tests {
     #[test]
     fn display_missing_semicolon() {
         let code = Code::with_file_name("/ {}", "fname", ParserContext::default());
-        let (_, diag) = code.parse(
-            Parser::file
-        );
+        let (_, diag) = code.parse(Parser::file);
         assert_eq!(
             diag,
             vec![Diagnostic::new(
@@ -276,11 +274,10 @@ error --> fname:1:5
         / {
             very-long-company,very-long-name;
         };",
-            "fname", ParserContext::default(),
+            "fname",
+            ParserContext::default(),
         );
-        let (_, diag) = code.parse(
-            Parser::file
-        );
+        let (_, diag) = code.parse(Parser::file);
         let printer = DiagnosticPrinter {
             diagnostics: &diag,
             code: code

--- a/ginko/src/dts/diagnostics.rs
+++ b/ginko/src/dts/diagnostics.rs
@@ -233,12 +233,17 @@ mod tests {
     use crate::dts::error_codes::SeverityMap;
     use crate::dts::parser::Parser;
     use crate::dts::test::Code;
+    use crate::dts::ParserContext;
     use itertools::Itertools;
 
     #[test]
     fn display_missing_semicolon() {
-        let code = Code::with_file_name("/ {}", "fname");
-        let (_, diag) = code.parse(Parser::file);
+        let code = Code::with_file_name("/ {}", "fname", ParserContext {
+          include_paths: Vec::new(),
+      },);
+        let (_, diag) = code.parse(
+            Parser::file
+        );
         assert_eq!(
             diag,
             vec![Diagnostic::new(
@@ -271,11 +276,15 @@ error --> fname:1:5
         /dts-v1/;
 
         / {
-            very-long-company,very-long-name;    
+            very-long-company,very-long-name;
         };",
-            "fname",
+            "fname", ParserContext {
+              include_paths: Vec::new(),
+          },
         );
-        let (_, diag) = code.parse(Parser::file);
+        let (_, diag) = code.parse(
+            Parser::file
+        );
         let printer = DiagnosticPrinter {
             diagnostics: &diag,
             code: code
@@ -288,7 +297,7 @@ error --> fname:1:5
         let formatter_err = "\
 warning --> fname:4:13
   |
-4 |             very-long-company,very-long-name;    
+4 |             very-long-company,very-long-name;
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ property should only have 31 characters but has 32 characters
 
 ".to_string();

--- a/ginko/src/dts/diagnostics.rs
+++ b/ginko/src/dts/diagnostics.rs
@@ -238,9 +238,7 @@ mod tests {
 
     #[test]
     fn display_missing_semicolon() {
-        let code = Code::with_file_name("/ {}", "fname", ParserContext {
-          include_paths: Vec::new(),
-      },);
+        let code = Code::with_file_name("/ {}", "fname", ParserContext::default());
         let (_, diag) = code.parse(
             Parser::file
         );
@@ -278,9 +276,7 @@ error --> fname:1:5
         / {
             very-long-company,very-long-name;
         };",
-            "fname", ParserContext {
-              include_paths: Vec::new(),
-          },
+            "fname", ParserContext::default(),
         );
         let (_, diag) = code.parse(
             Parser::file

--- a/ginko/src/dts/mod.rs
+++ b/ginko/src/dts/mod.rs
@@ -18,5 +18,6 @@ pub use data::{FileType, HasSpan, Position, Span};
 pub use diagnostics::{Diagnostic, DiagnosticPrinter, Severity};
 pub use error_codes::{ErrorCode, SeverityMap};
 pub use parser::Parser;
+pub use parser::ParserContext;
 pub use project::Project;
 pub use visitor::ItemAtCursor;

--- a/ginko/src/dts/parser.rs
+++ b/ginko/src/dts/parser.rs
@@ -798,24 +798,18 @@ mod test {
     use crate::dts::test::Code;
     use crate::dts::tokens::CompilerDirective::OmitIfNoRef;
     use crate::dts::tokens::TokenKind::{Directive, Equal, OpenBrace, Semicolon};
-    use crate::dts::{AnyDirective, HasSpan, ParserContext, Position, Primary};
+    use crate::dts::{AnyDirective, HasSpan, Position, Primary};
     use std::sync::Arc;
     use std::vec;
 
     #[test]
     pub fn string_properties() {
-        let code = Code::new(
-            "\"\"",
-            ParserContext::default(),
-        );
+        let code = Code::new("\"\"");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::String(WithToken::new("".into(), code.token()))
         );
-        let code = Code::new(
-            "\"bar\"",
-            ParserContext::default(),
-        );
+        let code = Code::new("\"bar\"");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::String(WithToken::new("bar".into(), code.token()))
@@ -831,7 +825,6 @@ mod test {
 / {
     some_prop = <5>
 }",
-            ParserContext::default(),
         );
         let (_, diagnostics) = code.parse_ok(Parser::file);
         assert_eq!(
@@ -854,18 +847,12 @@ mod test {
 
     #[test]
     pub fn cell_properties() {
-        let code = Code::new(
-            "<>",
-            ParserContext::default(),
-        );
+        let code = Code::new("<>");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Cells(code.s1("<").token(), vec![], code.s1(">").token())
         );
-        let code = Code::new(
-            "<0>",
-            ParserContext::default(),
-        );
+        let code = Code::new("<0>");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Cells(
@@ -874,10 +861,7 @@ mod test {
                 code.s1(">").token(),
             )
         );
-        let code = Code::new(
-            "<4>",
-            ParserContext::default(),
-        );
+        let code = Code::new("<4>");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Cells(
@@ -886,10 +870,7 @@ mod test {
                 code.s1(">").token(),
             )
         );
-        let code = Code::new(
-            "<4 17>",
-            ParserContext::default(),
-        );
+        let code = Code::new("<4 17>");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Cells(
@@ -901,10 +882,7 @@ mod test {
                 code.s1(">").token(),
             )
         );
-        let code = Code::new(
-            "<17 0xC>",
-            ParserContext::default(),
-        );
+        let code = Code::new("<17 0xC>");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Cells(
@@ -916,10 +894,7 @@ mod test {
                 code.s1(">").token(),
             )
         );
-        let code = Code::new(
-            "<17 &label>",
-            ParserContext::default(),
-        );
+        let code = Code::new("<17 &label>");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Cells(
@@ -938,10 +913,7 @@ mod test {
 
     #[test]
     pub fn reference_properties() {
-        let code = Code::new(
-            "&my_ref",
-            ParserContext::default(),
-        );
+        let code = Code::new("&my_ref");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Reference(WithToken::new(
@@ -949,10 +921,7 @@ mod test {
                 code.token(),
             ))
         );
-        let code = Code::new(
-            "&{/path/to/somewhere@2000}",
-            ParserContext::default(),
-        );
+        let code = Code::new("&{/path/to/somewhere@2000}");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::Reference(WithToken::new(
@@ -968,18 +937,12 @@ mod test {
 
     #[test]
     pub fn byte_strings() {
-        let code = Code::new(
-            "[]",
-            ParserContext::default(),
-        );
+        let code = Code::new("[]");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::ByteStrings(code.s1("[").token(), vec![], code.s1("]").token())
         );
-        let code = Code::new(
-            "[000012345678]",
-            ParserContext::default(),
-        );
+        let code = Code::new("[000012345678]");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::ByteStrings(
@@ -991,10 +954,7 @@ mod test {
                 code.s1("]").token(),
             )
         );
-        let code = Code::new(
-            "[00 00 12 34 56 78]",
-            ParserContext::default(),
-        );
+        let code = Code::new("[00 00 12 34 56 78]");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::ByteStrings(
@@ -1010,10 +970,7 @@ mod test {
                 code.s1("]").token(),
             )
         );
-        let code = Code::new(
-            "[AB CD]",
-            ParserContext::default(),
-        );
+        let code = Code::new("[AB CD]");
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
             PropertyValue::ByteStrings(
@@ -1029,10 +986,7 @@ mod test {
 
     #[test]
     pub fn simple_file() {
-        let code = Code::new(
-            "/ {};",
-            ParserContext::default(),
-        );
+        let code = Code::new("/ {};");
         let node = code.parse_ok_no_diagnostics(Parser::file);
         code.s1(";");
         assert_eq!(
@@ -1059,7 +1013,6 @@ mod test {
 /dts-v1/;
 
 /{};",
-            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1093,7 +1046,6 @@ mod test {
         // my sub node
     };
 };",
-            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1143,7 +1095,6 @@ mod test {
             reg = <0x10000000 0x100>;
         };
     };",
-            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1224,7 +1175,6 @@ mod test {
         };
         some_prop = <0x1>;
     };",
-            ParserContext::default(),
         );
         let (_, diag) = code.parse_ok(Parser::file);
         assert_eq!(
@@ -1255,7 +1205,6 @@ mod test {
 
     / {};
     ",
-            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1296,7 +1245,6 @@ mod test {
         str = start: \"string value\" end: ;
     };
     ",
-            ParserContext::default(),
         )
         .parse_ok_no_diagnostics(Parser::file);
     }
@@ -1312,7 +1260,6 @@ mod test {
         some_prop = <(1 + 1) (2 || (3 - 4)) ()>;
     };
     ",
-            ParserContext::default(),
         )
         .parse_ok_no_diagnostics(Parser::file);
     }
@@ -1327,7 +1274,6 @@ mod test {
 
     / {};
     ",
-            ParserContext::default(),
         )
         .parse_ok_no_diagnostics(Parser::file);
     }
@@ -1343,7 +1289,6 @@ mod test {
         prop_b;
     };
     ",
-            ParserContext::default(),
         );
         let (res, _) = code.parse(Parser::file);
 
@@ -1367,7 +1312,6 @@ mod test {
         }
 
         ",
-            ParserContext::default(),
         );
         let (_, diag) = code.parse_ok(Parser::file);
 
@@ -1391,7 +1335,6 @@ mod test {
     };
 };
         ",
-            ParserContext::default(),
         );
         let primary = code.parse_ok_no_diagnostics(Parser::primary);
 
@@ -1432,7 +1375,6 @@ mod test {
 /delete-node/ &some_node;
 /delete-node/ &{/path/to/node};
         ",
-            ParserContext::default(),
         );
         let file = code.parse_ok_no_diagnostics(Parser::file);
 
@@ -1471,7 +1413,6 @@ mod test {
     /omit-if-no-ref/ node1_lbl: node1 {};
 };
         ",
-            ParserContext::default(),
         );
         let file = code.parse_ok_no_diagnostics(Parser::file);
 
@@ -1514,7 +1455,6 @@ mod test {
 
 /omit-if-no-ref/ &node2;
         ",
-            ParserContext::default(),
         );
         let file = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(

--- a/ginko/src/dts/parser.rs
+++ b/ginko/src/dts/parser.rs
@@ -12,16 +12,9 @@ use itertools::Itertools;
 use std::path::{Path as StdPath, PathBuf};
 use std::sync::Arc;
 
+#[derive(Clone, Default)]
 pub struct ParserContext {
     pub include_paths: Vec<PathBuf>,
-}
-
-impl Clone for ParserContext {
-    fn clone(&self) -> Self {
-        ParserContext {
-            include_paths: self.include_paths.clone(),
-        }
-    }
 }
 
 /// The `Parser` class is responsible for syntactical analysis,
@@ -813,9 +806,7 @@ mod test {
     pub fn string_properties() {
         let code = Code::new(
             "\"\"",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -823,9 +814,7 @@ mod test {
         );
         let code = Code::new(
             "\"bar\"",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -842,9 +831,7 @@ mod test {
 / {
     some_prop = <5>
 }",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let (_, diagnostics) = code.parse_ok(Parser::file);
         assert_eq!(
@@ -869,9 +856,7 @@ mod test {
     pub fn cell_properties() {
         let code = Code::new(
             "<>",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -879,9 +864,7 @@ mod test {
         );
         let code = Code::new(
             "<0>",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -893,9 +876,7 @@ mod test {
         );
         let code = Code::new(
             "<4>",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -907,9 +888,7 @@ mod test {
         );
         let code = Code::new(
             "<4 17>",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -924,9 +903,7 @@ mod test {
         );
         let code = Code::new(
             "<17 0xC>",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -941,9 +918,7 @@ mod test {
         );
         let code = Code::new(
             "<17 &label>",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -965,9 +940,7 @@ mod test {
     pub fn reference_properties() {
         let code = Code::new(
             "&my_ref",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -978,9 +951,7 @@ mod test {
         );
         let code = Code::new(
             "&{/path/to/somewhere@2000}",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -999,9 +970,7 @@ mod test {
     pub fn byte_strings() {
         let code = Code::new(
             "[]",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -1009,9 +978,7 @@ mod test {
         );
         let code = Code::new(
             "[000012345678]",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -1026,9 +993,7 @@ mod test {
         );
         let code = Code::new(
             "[00 00 12 34 56 78]",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -1047,9 +1012,7 @@ mod test {
         );
         let code = Code::new(
             "[AB CD]",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         assert_eq!(
             code.parse_ok_no_diagnostics(Parser::property_value),
@@ -1068,9 +1031,7 @@ mod test {
     pub fn simple_file() {
         let code = Code::new(
             "/ {};",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         code.s1(";");
@@ -1098,9 +1059,7 @@ mod test {
 /dts-v1/;
 
 /{};",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1134,9 +1093,7 @@ mod test {
         // my sub node
     };
 };",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1186,9 +1143,7 @@ mod test {
             reg = <0x10000000 0x100>;
         };
     };",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1269,9 +1224,7 @@ mod test {
         };
         some_prop = <0x1>;
     };",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let (_, diag) = code.parse_ok(Parser::file);
         assert_eq!(
@@ -1302,9 +1255,7 @@ mod test {
 
     / {};
     ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let node = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(
@@ -1345,9 +1296,7 @@ mod test {
         str = start: \"string value\" end: ;
     };
     ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         )
         .parse_ok_no_diagnostics(Parser::file);
     }
@@ -1363,9 +1312,7 @@ mod test {
         some_prop = <(1 + 1) (2 || (3 - 4)) ()>;
     };
     ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         )
         .parse_ok_no_diagnostics(Parser::file);
     }
@@ -1380,9 +1327,7 @@ mod test {
 
     / {};
     ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         )
         .parse_ok_no_diagnostics(Parser::file);
     }
@@ -1398,9 +1343,7 @@ mod test {
         prop_b;
     };
     ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let (res, _) = code.parse(Parser::file);
 
@@ -1424,9 +1367,7 @@ mod test {
         }
 
         ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let (_, diag) = code.parse_ok(Parser::file);
 
@@ -1450,9 +1391,7 @@ mod test {
     };
 };
         ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let primary = code.parse_ok_no_diagnostics(Parser::primary);
 
@@ -1493,9 +1432,7 @@ mod test {
 /delete-node/ &some_node;
 /delete-node/ &{/path/to/node};
         ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let file = code.parse_ok_no_diagnostics(Parser::file);
 
@@ -1534,9 +1471,7 @@ mod test {
     /omit-if-no-ref/ node1_lbl: node1 {};
 };
         ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let file = code.parse_ok_no_diagnostics(Parser::file);
 
@@ -1579,9 +1514,7 @@ mod test {
 
 /omit-if-no-ref/ &node2;
         ",
-            ParserContext {
-                include_paths: Vec::new(),
-            },
+            ParserContext::default(),
         );
         let file = code.parse_ok_no_diagnostics(Parser::file);
         assert_eq!(

--- a/ginko/src/dts/project.rs
+++ b/ginko/src/dts/project.rs
@@ -83,16 +83,11 @@ impl Project {
         &mut self,
         include_paths: Option<Vec<String>>,
     ) -> Result<(), io::Error> {
-        self.include_paths = Vec::new();
-
-        if include_paths.is_none() {
-            return Ok(());
-        }
-
-        for path in include_paths.unwrap().iter_mut() {
-            self.include_paths.push(dunce::canonicalize(path)?);
-        }
-
+        self.include_paths = include_paths
+            .unwrap_or_default()
+            .iter()
+            .map(|path| dunce::canonicalize(path))
+            .collect::<Result<Vec<_>, io::Error>>()?;
         Ok(())
     }
 

--- a/ginko/src/dts/project.rs
+++ b/ginko/src/dts/project.rs
@@ -335,9 +335,7 @@ mod tests {
         ) -> (Code, PathBuf) {
             let code = Code::new(
                 content.as_ref(),
-                ParserContext {
-                    include_paths: Vec::new(),
-                },
+                ParserContext::default(),
             );
             let file_path = self.inner.path().join(name);
 

--- a/ginko/src/dts/project.rs
+++ b/ginko/src/dts/project.rs
@@ -79,10 +79,7 @@ pub struct Project {
 }
 
 impl Project {
-    pub fn set_include_paths(
-        &mut self,
-        include_paths: Vec<String>,
-    ) {
+    pub fn set_include_paths(&mut self, include_paths: Vec<String>) {
         self.include_paths = include_paths
             .iter()
             .map(|path| dunce::canonicalize(path).unwrap_or_default())
@@ -331,9 +328,7 @@ mod tests {
             name: impl AsRef<Path>,
             content: impl AsRef<str>,
         ) -> (Code, PathBuf) {
-            let code = Code::new(
-                content.as_ref(),
-            );
+            let code = Code::new(content.as_ref());
             let file_path = self.inner.path().join(name);
 
             fs::write(&file_path, code.code()).expect("Cannot write to file");
@@ -608,14 +603,12 @@ mod tests {
         let temp_dir = TempDir::new();
         let (_, file3) = temp_dir.add_file(
             "test.dts",
-            format!(
-                r#"
+            r#"
 /dts-v1/;
 
 /include/ "tests-include1.dtsi"
 /include/ "tests-include2.dtsi"
 "#,
-            ),
         );
 
         let mut project = Project::default();
@@ -624,7 +617,7 @@ mod tests {
             another_includes_dir.inner.path().display().to_string(),
         ];
 
-        let _ = project.set_include_paths(include_paths);
+        project.set_include_paths(include_paths);
 
         project
             .add_file(file3.clone().into_os_string().into_string().unwrap())

--- a/ginko/src/dts/project.rs
+++ b/ginko/src/dts/project.rs
@@ -81,14 +81,12 @@ pub struct Project {
 impl Project {
     pub fn set_include_paths(
         &mut self,
-        include_paths: Option<Vec<String>>,
-    ) -> Result<(), io::Error> {
+        include_paths: Vec<String>,
+    ) {
         self.include_paths = include_paths
-            .unwrap_or_default()
             .iter()
-            .map(|path| dunce::canonicalize(path))
-            .collect::<Result<Vec<_>, io::Error>>()?;
-        Ok(())
+            .map(|path| dunce::canonicalize(path).unwrap_or_default())
+            .collect::<Vec<PathBuf>>();
     }
 
     pub fn add_file(&mut self, file_name: String) -> Result<(), io::Error> {
@@ -309,7 +307,7 @@ mod tests {
     use crate::dts::error_codes::ErrorCode;
     use crate::dts::test::Code;
     use crate::dts::tokens::TokenKind;
-    use crate::dts::{ast, Diagnostic, HasSpan, ItemAtCursor, ParserContext, Project};
+    use crate::dts::{ast, Diagnostic, HasSpan, ItemAtCursor, Project};
     use assert_matches::assert_matches;
     use itertools::Itertools;
     use std::fs;
@@ -335,7 +333,6 @@ mod tests {
         ) -> (Code, PathBuf) {
             let code = Code::new(
                 content.as_ref(),
-                ParserContext::default(),
             );
             let file_path = self.inner.path().join(name);
 
@@ -622,10 +619,10 @@ mod tests {
         );
 
         let mut project = Project::default();
-        let include_paths = Some(vec![
+        let include_paths = vec![
             includes_dir.inner.path().display().to_string(),
             another_includes_dir.inner.path().display().to_string(),
-        ]);
+        ];
 
         let _ = project.set_include_paths(include_paths);
 

--- a/ginko/src/dts/test.rs
+++ b/ginko/src/dts/test.rs
@@ -57,6 +57,7 @@ impl Code {
         Code::with_file_name(code, "inline source", ParserContext::default())
     }
 
+    #[allow(unused)]
     pub fn with_context(code: &str, context: ParserContext) -> Code {
         Code::with_file_name(code, "inline source", context)
     }

--- a/ginko/src/dts/test.rs
+++ b/ginko/src/dts/test.rs
@@ -2,7 +2,7 @@ use crate::dts::analysis::{Analysis, AnalysisContext, AnalysisResult};
 use crate::dts::data::HasSource;
 use crate::dts::reader::{ByteReader, Reader};
 use crate::dts::tokens::{Lexer, Token};
-use crate::dts::{Diagnostic, FileType, HasSpan, Parser, Position, Project, Span, ParserContext};
+use crate::dts::{Diagnostic, FileType, HasSpan, Parser, ParserContext, Position, Project, Span};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -11,7 +11,7 @@ pub struct Code {
     pos: Span,
     code: String,
     source: Arc<Path>,
-    parser_context: ParserContext
+    parser_context: ParserContext,
 }
 
 impl HasSpan for Code {
@@ -53,7 +53,11 @@ impl HasSource for Code {
 }
 
 impl Code {
-    pub fn new(code: &str, context: ParserContext) -> Code {
+    pub fn new(code: &str) -> Code {
+        Code::with_file_name(code, "inline source", ParserContext::default())
+    }
+
+    pub fn with_context(code: &str, context: ParserContext) -> Code {
         Code::with_file_name(code, "inline source", context)
     }
 
@@ -68,7 +72,7 @@ impl Code {
             pos: Span::new(Position::zero(), last_pos),
             code: code.into(),
             source: Arc::from(PathBuf::from(file_name)),
-            parser_context: context
+            parser_context: context,
         }
     }
 
@@ -83,10 +87,7 @@ impl Code {
         let mut reader = ByteReader::from_string(self.code.clone());
         reader.seek(self.pos.start());
         let lexer = Lexer::new(reader, self.source.clone());
-        let mut parser = Parser::new(
-            lexer,
-            self.parser_context.clone()
-        );
+        let mut parser = Parser::new(lexer, self.parser_context.clone());
         (parse_fn(&mut parser), parser.diagnostics)
     }
 
@@ -128,7 +129,7 @@ impl Code {
             code: self.code.clone(),
             pos: span,
             source: self.source.clone(),
-            parser_context: self.parser_context.clone()
+            parser_context: self.parser_context.clone(),
         }
     }
 

--- a/ginko/src/main.rs
+++ b/ginko/src/main.rs
@@ -8,8 +8,8 @@ use std::process::exit;
 #[command(author, version, about, long_about = None)]
 struct Args {
     file: String,
-    #[arg(short, long, help="Add a path to search for include files")]
-    include: Option<Vec<String>>
+    #[arg(short, long, help = "Add a path to search for include files")]
+    include: Option<Vec<String>>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/ginko/src/main.rs
+++ b/ginko/src/main.rs
@@ -2,20 +2,23 @@ use clap::Parser;
 use ginko::dts::{DiagnosticPrinter, Project, SeverityMap};
 use itertools::Itertools;
 use std::error::Error;
-use std::path::PathBuf;
 use std::process::exit;
 
 #[derive(clap::Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     file: String,
+    #[arg(short, long, help="Add a path to search for include files")]
+    include: Option<Vec<String>>
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let mut project = Project::default();
-    let file_name = PathBuf::from(args.file);
-    project.add_file(file_name)?;
+
+    // let include_path =
+    project.set_include_paths(args.include)?;
+    project.add_file(args.file)?;
 
     let mut has_errors = false;
     for file in project.project_files() {

--- a/ginko/src/main.rs
+++ b/ginko/src/main.rs
@@ -16,8 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
     let mut project = Project::default();
 
-    // let include_path =
-    project.set_include_paths(args.include)?;
+    project.set_include_paths(args.include.unwrap_or_default());
     project.add_file(args.file)?;
 
     let mut has_errors = false;

--- a/ginko/tests/integration_tests.rs
+++ b/ginko/tests/integration_tests.rs
@@ -19,7 +19,9 @@ fn no_diagnostics_for_simple_file() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut file_name = path.clone();
     file_name.push("tests/simple.dts");
-    project.add_file(file_name.into_os_string().into_string().unwrap()).expect("File should be present");
+    project
+        .add_file(file_name.into_os_string().into_string().unwrap())
+        .expect("File should be present");
     check_no_diagnostics(&project);
 }
 
@@ -29,9 +31,13 @@ fn no_diagnostics_for_file_with_delete_node() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut file_name = path.clone();
     file_name.push("tests/test_delete_syntax_A.dts");
-    project.add_file(file_name.into_os_string().into_string().unwrap()).expect("File should be present");
+    project
+        .add_file(file_name.into_os_string().into_string().unwrap())
+        .expect("File should be present");
     let mut file_name = path.clone();
     file_name.push("tests/test_delete_syntax_B.dts");
-    project.add_file(file_name.into_os_string().into_string().unwrap()).expect("File should be present");
+    project
+        .add_file(file_name.into_os_string().into_string().unwrap())
+        .expect("File should be present");
     check_no_diagnostics(&project);
 }

--- a/ginko/tests/integration_tests.rs
+++ b/ginko/tests/integration_tests.rs
@@ -19,7 +19,7 @@ fn no_diagnostics_for_simple_file() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut file_name = path.clone();
     file_name.push("tests/simple.dts");
-    project.add_file(file_name).expect("File should be present");
+    project.add_file(file_name.into_os_string().into_string().unwrap()).expect("File should be present");
     check_no_diagnostics(&project);
 }
 
@@ -29,9 +29,9 @@ fn no_diagnostics_for_file_with_delete_node() {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let mut file_name = path.clone();
     file_name.push("tests/test_delete_syntax_A.dts");
-    project.add_file(file_name).expect("File should be present");
+    project.add_file(file_name.into_os_string().into_string().unwrap()).expect("File should be present");
     let mut file_name = path.clone();
     file_name.push("tests/test_delete_syntax_B.dts");
-    project.add_file(file_name).expect("File should be present");
+    project.add_file(file_name.into_os_string().into_string().unwrap()).expect("File should be present");
     check_no_diagnostics(&project);
 }

--- a/ginko_ls/Cargo.toml
+++ b/ginko_ls/Cargo.toml
@@ -19,3 +19,5 @@ tracing-subscriber = "0.3.18"
 ginko = { version = "^0.0.5", path = "../ginko" }
 url = "2.5.0"
 clap = { version = "4.4.18", features = ["derive"] }
+serde = "1.0"
+serde_json = "1.0"

--- a/ginko_ls/src/main.rs
+++ b/ginko_ls/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use server::{Backend, BackendOptions};
 use tower_lsp::{LspService, Server};
 
 mod server;
@@ -11,25 +10,16 @@ struct Args {
     include: Option<Vec<String>>,
 }
 
-#[tokio::main]
-pub async fn main() {
-    let args = Args::parse();
-    // Log to stderr instead of stdout since communication with the language server client
-    // happens through stdout
-    tracing_subscriber::fmt()
-        .with_writer(std::io::stderr)
-        .init();
-    tracing_subscriber::fmt().init();
+#[tokio::main]pub async fn main() {
+  Args::parse();
+  // Log to stderr instead of stdout since communication with the language server client
+  // happens through stdout
+  tracing_subscriber::fmt()
+      .with_writer(std::io::stderr)
+      .init();
 
-    let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
+  let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
 
-    let (service, socket) = LspService::new(|client| {
-        Backend::new(
-            client,
-            BackendOptions {
-                include_paths: args.include,
-            },
-        )
-    });
-    Server::new(stdin, stdout, socket).serve(service).await;
+  let (service, socket) = LspService::new(server::Backend::new);
+  Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/ginko_ls/src/main.rs
+++ b/ginko_ls/src/main.rs
@@ -1,23 +1,35 @@
 use clap::Parser;
+use server::{Backend, BackendOptions};
 use tower_lsp::{LspService, Server};
 
 mod server;
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
-struct Args {}
+struct Args {
+    #[arg(short, long, help = "Add a path to search for include files")]
+    include: Option<Vec<String>>,
+}
 
 #[tokio::main]
 pub async fn main() {
-    Args::parse();
+    let args = Args::parse();
     // Log to stderr instead of stdout since communication with the language server client
     // happens through stdout
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .init();
+    tracing_subscriber::fmt().init();
 
     let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
 
-    let (service, socket) = LspService::new(server::Backend::new);
+    let (service, socket) = LspService::new(|client| {
+        Backend::new(
+            client,
+            BackendOptions {
+                include_paths: args.include,
+            },
+        )
+    });
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/ginko_ls/src/main.rs
+++ b/ginko_ls/src/main.rs
@@ -10,16 +10,17 @@ struct Args {
     include: Option<Vec<String>>,
 }
 
-#[tokio::main]pub async fn main() {
-  Args::parse();
-  // Log to stderr instead of stdout since communication with the language server client
-  // happens through stdout
-  tracing_subscriber::fmt()
-      .with_writer(std::io::stderr)
-      .init();
+#[tokio::main]
+pub async fn main() {
+    Args::parse();
+    // Log to stderr instead of stdout since communication with the language server client
+    // happens through stdout
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .init();
 
-  let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
+    let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
 
-  let (service, socket) = LspService::new(server::Backend::new);
-  Server::new(stdin, stdout, socket).serve(service).await;
+    let (service, socket) = LspService::new(server::Backend::new);
+    Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/ginko_ls/src/server.rs
+++ b/ginko_ls/src/server.rs
@@ -10,6 +10,10 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 use url::Url;
 
+pub struct BackendOptions {
+    pub include_paths: Option<Vec<String>>,
+}
+
 pub(crate) struct Backend {
     client: Client,
     project: RwLock<Project>,
@@ -17,10 +21,13 @@ pub(crate) struct Backend {
 }
 
 impl Backend {
-    pub fn new(client: Client) -> Backend {
+    pub fn new(client: Client, options: BackendOptions) -> Backend {
+        let mut project = Project::default();
+        let _ = project.set_include_paths(options.include_paths);
+
         Backend {
             client,
-            project: RwLock::new(Project::default()),
+            project: RwLock::new(project),
             severities: SeverityMap::default(),
         }
     }


### PR DESCRIPTION
First of all thanks for the efforts implementing a dts parser and language server 👍 I've added an `--include` option that adds the ability to search for dtsi files in multiple directories. It behaves similar to `dtc` option flag. Feedback is highly appreciated.