### PR TITLE
Add automatic builds for `x86_64-pc-windows-gnu` target

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,7 @@ jobs:
           - ginko_ls
         target:
           - x86_64-unknown-linux-gnu
+          - x86_64-pc-windows-gnu
           - x86_64-pc-windows-msvc
           - aarch64-apple-darwin
         rust:
@@ -45,6 +46,9 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             ext: ""
+          - target: x86_64-pc-windows-gnu
+            os: windows-latest
+            ext: .exe
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             ext: .exe
@@ -128,6 +132,8 @@ jobs:
           chmod +x */bin/ginko*
           zip -r ginko-x86_64-unknown-linux-gnu.zip ginko-x86_64-unknown-linux-gnu
           zip -r ginko_ls-x86_64-unknown-linux-gnu.zip ginko_ls-x86_64-unknown-linux-gnu
+          zip -r ginko-x86_64-pc-windows-gnu.zip ginko-x86_64-pc-windows-gnu
+          zip -r ginko_ls-x86_64-pc-windows-gnu.zip ginko_ls-x86_64-pc-windows-gnu
           zip -r ginko-x86_64-pc-windows-msvc.zip ginko-x86_64-pc-windows-msvc
           zip -r ginko_ls-x86_64-pc-windows-msvc.zip ginko_ls-x86_64-pc-windows-msvc
           zip -r ginko-aarch64-apple-darwin.zip ginko-aarch64-apple-darwin


### PR DESCRIPTION
I'd like to have fully self-contained `ginko`/`ginko_ls` binaries. The currently available binaries created for the `x86_64-pc-windows-msvc` target depend on the `VCRUNTIME140.DLL` file. This file doesn't come with Windows. You're also not supposed to redistribute it along with your application. The only official way to get that DLL is to launch the installer of the Visual C++ redistributable package.

An alternative is building `ginko`/`ginko_ls` for the `x86_64-pc-windows-gnu` target. Binaries created for that target are a little larger, but only depend on Windows system libraries. No extra DLL needs to be installed/redistributed and the resulting binaries can be used on any fresh Windows installation.

My PR adds that target to GitHub Actions. Would love to see it in the next release :)