### PR TITLE
Let unknown file endings through as FileType::Unknown

### DIFF
--- a/ginko_ls/src/server.rs
+++ b/ginko_ls/src/server.rs
@@ -143,10 +143,6 @@ impl LanguageServer for Backend {
             return;
         };
         let file_type = FileType::from(file_path.as_path());
-        if file_type == FileType::Unknown {
-            self.client.show_message(MessageType::WARNING, format!("File {} cannot be associated to a device-tree source. Make sure it has the ending 'dts', 'dtsi' or 'dtso'", file_path.to_string_lossy())).await;
-            return;
-        }
         self.project.write().add_file_with_text(
             file_path.clone(),
             params.text_document.text,


### PR DESCRIPTION
This allows for the client to feed in additional custom extensions. The spec only goes for "Should" in all of its extension naming conventions, so trying to analyze files with extensions configured in the language client but unknown to the library should not be blocked at this stage.