### PR TITLE
Improve handling of `/Include/` statements

### DIFF
--- a/ginko/src/dts/project.rs
+++ b/ginko/src/dts/project.rs
@@ -240,12 +240,12 @@ impl Project {
     fn parse_file(&mut self, file_name: PathBuf, text: String, file_type: FileType) {
         let reader = ByteReader::from_string(text.clone());
         let lexer = Lexer::new(reader, file_name.clone().into());
-        let mut parser = Parser::new(
-            lexer,
-            ParserContext {
-                include_paths: self.include_paths.clone(),
-            },
-        );
+        // add the file's directory to the include paths to allow local includes
+        let mut include_paths = self.include_paths.clone();
+        if let Some(parent) = file_name.parent() {
+            include_paths.insert(0, parent.into());
+        }
+        let mut parser = Parser::new(lexer, ParserContext { include_paths });
         match parser.file() {
             Ok(file) => {
                 // insert dummy file to be defined so that no cyclic dependency can occur.

--- a/ginko_ls/src/server.rs
+++ b/ginko_ls/src/server.rs
@@ -6,7 +6,7 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
@@ -199,10 +199,14 @@ impl LanguageServer for Backend {
                 }
             }
             ItemAtCursor::Include(include) => {
-                match Url::from_file_path(Path::new(include.file_name.item())) {
-                    Ok(url) => Ok(Some(GotoDefinitionResponse::Scalar(Location::new(
+                match include
+                    .path()
+                    .ok()
+                    .and_then(|path| Url::from_file_path(path).ok())
+                {
+                    Some(url) => Ok(Some(GotoDefinitionResponse::Scalar(Location::new(
                         url,
-                        Range::default(),
+                        ginko_span_to_range(include.span()),
                     )))),
                     _ => Ok(None),
                 }


### PR DESCRIPTION
- allows includes to work that are relative to the current file
- makes the language server return an URL to goto definition that works again